### PR TITLE
change config get to getfloat for radar lat/lon

### DIFF
--- a/scripts/matchvol.py
+++ b/scripts/matchvol.py
@@ -197,8 +197,8 @@ def main():
     # Radar location too.
     GR_param = config['radar']
     rid = GR_param.get('radar_id')
-    radar_lat = GR_param.get('latitude')
-    radar_lon = GR_param.get('longitude')
+    radar_lat = GR_param.getfloat('latitude')
+    radar_lon = GR_param.getfloat('longitude')
     try:
         gr_offset = GR_param.getfloat('offset')
     except KeyError:


### PR DESCRIPTION
I left it as get instead of getfloat when reading the radar lat/lon from the config file. These vars needs to be floats for the distance calcs